### PR TITLE
Update PwmRead.py

### DIFF
--- a/navigation-final/PwmRead.py
+++ b/navigation-final/PwmRead.py
@@ -55,7 +55,10 @@ class PwmRead:
         sum = 0.0
         num_error = 0
         for i in range(self.num_cycles):
-            GPIO.wait_for_edge(self.pin_mode, GPIO.RISING)
+            GPIO.wait_for_edge(self.pin_mode, GPIO.RISING, timeout = 500)
+            if channel is None:
+                self.pulth_width[0] = 100 #値は範囲外のもので適当に置いた
+                break
             start = time.time()
             GPIO.wait_for_edge(self.pin_mode, GPIO.FALLING)
             pulse = (time.time() - start) * 1000 * 1000


### PR DESCRIPTION
out of range の時に信号が検出されない関係でmodeが切り替えられない仕様になっ
ていたので、timeoutを設定することで自動的にoutofrangeのmodeになるようにしました
（全体のtime_sleepが1秒なのでとりあえず0.5秒にしてみました）